### PR TITLE
Simplifying the install

### DIFF
--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -18,8 +18,6 @@ import functools
 import schwimmbad
 import psutil
 from tqdm import tqdm
-from IPython import embed
-import matplotlib.pyplot as plt
 import warnings
 try:
     print = functools.partial(

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -23,7 +23,6 @@ from tqdm import tqdm, trange
 from racs_tools import au2
 import functools
 import psutil
-from IPython import embed
 try:
     from mpi4py import MPI
     mpiSwitch = True

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,13 @@ VERSION = '1.0.5'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'astropy', 'radio_beam', 'schwimmbad', 'psutil', 'matplotlib',
-    'scipy', 'numpy', 'spectral_cube', 'tqdm', 'ipython', 'mpi4py'
+    'astropy', 'radio_beam', 'schwimmbad', 'psutil', 
+    'scipy', 'numpy', 'spectral_cube', 'tqdm', 
 ]
 
 # What packages are optional?
 EXTRAS = {
+        'mpi': ['mpi4py'],
     # 'fancy feature': ['django'],
 }
 


### PR DESCRIPTION
I removed some packages from `setup.py` since they were not needed (e.g., `matplotlib`, `ipython`)

I made `mpi4py` optional in the install (I had trouble installing it locally, and it seemed like the code was set up to make its use optional).

I removed `imports` for `matplotlib` and `ipython` where I could find them.