### PR TITLE
use astropy.wcs rather than hard-coded CDELT for the pixel scales

### DIFF
--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.signal
 from astropy import units as u
 from astropy.io import fits, ascii
+import astropy.wcs
 from astropy.convolution import convolve, convolve_fft
 from astropy.table import Table
 from radio_beam import Beam, Beams
@@ -77,8 +78,11 @@ def getimdata(cubenm, verbose=False):
         print(f'Getting image data from {cubenm}')
     with fits.open(cubenm, memmap=True, mode='denywrite') as hdu:
 
-        dxas = hdu[0].header['CDELT1']*-1*u.deg
-        dyas = hdu[0].header['CDELT2']*u.deg
+        w = astropy.wcs.WCS(hdu[0])
+        pixelscales = astropy.wcs.utils.proj_plane_pixel_scales(w)
+
+        dxas = pixelscales[0]*u.deg
+        dyas = pixelscales[1]*u.deg
 
         nx, ny = hdu[0].data[0, 0, :,
                              :].shape[0], hdu[0].data[0, 0, :, :].shape[1]
@@ -247,8 +251,11 @@ def getmaxbeam(files, conv_mode='robust', target_beam=None, cutoff=None,
         pa=round_up(cmn_beam.pa.to(u.deg), decimals=2)
     )
     target_header = header
-    dx = target_header['CDELT1']*-1*u.deg
-    dy = target_header['CDELT2']*u.deg
+    w = astropy.wcs.WCS(target_header)
+    pixelscales = astropy.wcs.utils.proj_plane_pixel_scales(w)
+
+    dx = pixelscales[0]*u.deg
+    dy = pixelscales[1]*u.deg
     if not dx == dy:
         raise Exception("GRID MUST BE SAME IN X AND Y")
     grid = dy

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -15,6 +15,7 @@ import numpy as np
 import scipy.signal
 from astropy import units as u
 from astropy.io import fits, ascii
+import astropy.wcs
 from astropy.table import Table
 from spectral_cube import SpectralCube
 from radio_beam import Beam, Beams
@@ -327,9 +328,13 @@ def makedata(files, outdir, verbose=True):
         datadict[f"cube_{i}"]["outdir"] = out
         # Get metadata
         header = fits.getheader(file)
-        dxas = header['CDELT1']*-1*u.deg
+        w = astropy.wcs.WCS(header)
+        pixelscales = astropy.wcs.utils.proj_plane_pixel_scales(w)
+
+        dxas = pixelscales[0]*u.deg
+        dyas = pixelscales[1]*u.deg
+
         datadict[f"cube_{i}"]["dx"] = dxas
-        dyas = header['CDELT2']*u.deg
         datadict[f"cube_{i}"]["dy"] = dyas
         if not dxas == dyas:
             raise Exception("GRID MUST BE SAME IN X AND Y")


### PR DESCRIPTION
Previously `beamcon_2D` and `beamcon_3D` looked for `CDELT1` and `CDELT2` to get the pixel scales.  But some images have `CD` matrix for the astrometry.  So now this uses the method `astropy.wcs.utils.proj_plane_pixel_scales` which is more general.

(added import of `astropy.wcs` to make this work)