### PR TITLE
keeping sfactor computed by robust convolution explicitly

### DIFF
--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -126,6 +126,8 @@ def smooth(datadict, conv_mode='robust', verbose=False):
                 datadict['dx'],
                 datadict['dy'],
             )
+            # keep the new sfactor computed by this method
+            datadict["sfactor"] = fac
         if conv_mode == 'scipy':
             newim = scipy.signal.convolve(
                 datadict['image'].astype('f8'),


### PR DESCRIPTION
The robust convolution method computes a different `sfactor` than the other methods.  For bookkeeping, keep in in the metadata dictionary.