### PR TITLE
Ignore BeamError in deconvolve check where target_beam=beam

### DIFF
--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -561,6 +561,10 @@ def main(
             except ValueError:
                 mask_count += 1
                 failed.append(file)
+            except BeamError as be:
+                # BeamError should not be raised if beams are equal
+                if target_beam != beam:
+                    raise BeamError(be)
         if mask_count > 0:
             logger.warning("The following images could not reach target resolution:")
             logger.warning(failed)


### PR DESCRIPTION
Ignoring BeamError raised in `target_beam.deconvolve(beam)` when new beam = old beam since this check is in place in `worker` function later in code execution. 