### PR TITLE
Optionally return `datadict` from worker

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: tjg-racs-tools
+name: racs-tools
 channels:
 - astropy
 - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: racs-tools
+name: tjg-racs-tools
 channels:
 - astropy
 - conda-forge

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -196,6 +196,7 @@ def worker(
     prefix: str = "",
     cutoff: float = None,
     dryrun: bool = False,
+    return_datadict: bool = False
 ) -> dict:
     """Parallel worker function
 
@@ -208,6 +209,7 @@ def worker(
         prefix (str, optional): Filename prefix. Defaults to "".
         cutoff (float, optional): PSF cutoff. Defaults to None.
         dryrun (bool, optional): Do a dryrun. Defaults to False.
+        return_datadict (bool, optional): Return structure containing output data and associated header components. Defaults to False. 
 
     Returns:
         dict: Output data.
@@ -271,7 +273,8 @@ def worker(
             outdir=outdir,
         )
 
-    return datadict
+    if return_datadict:
+        return datadict
 
 
 def getmaxbeam(
@@ -598,6 +601,7 @@ def main(
                 prefix=prefix,
                 cutoff=cutoff,
                 dryrun=dryrun,
+                return_datadict=False
             ),
             files,
         )

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -470,6 +470,7 @@ def main(
     tolerance: float = 0.0001,
     nsamps: int = 200,
     epsilon: float = 0.0005,
+    return_datadict: bool=False
 ):
     """Main script.
 
@@ -490,7 +491,7 @@ def main(
         tolerance (float, optional): Common tolerance. Defaults to 0.0001.
         nsamps (int, optional): Common samples. Defaults to 200.
         epsilon (float, optional): Common epsilon. Defaults to 0.0005.
-
+        return_datadict (bool, optional): Return structure containing output data and associated header components. Defaults to False. 
 
     Raises:
         Exception: If no files are found.
@@ -590,6 +591,8 @@ def main(
 
     logger.info(f"Final beam is {new_beam!r}")
 
+    return_datadict = return_datadict if log is None else True
+
     output = list(
         pool.map(
             partial(
@@ -601,7 +604,7 @@ def main(
                 prefix=prefix,
                 cutoff=cutoff,
                 dryrun=dryrun,
-                return_datadict=False
+                return_datadict=return_datadict
             ),
             files,
         )


### PR DESCRIPTION
In the current version a data dictionary is return that contains a copy of the original image data, header and other associated components. Since these are being returned from the worker, the multiprocessing pool type worker will accumulate the results in memory. 

When a large set of images are being convolved to a common resolution, memory usage will quickly grow. In my situation I am convolving some 500 images, that eventually grows to about 300GB in memory. I can avoid this issue by 

From my reading the only time the `datadict` structure is used after results have been collected from the processing pool is when the `log` option is used. So, the option that controls whether `datadict` is return will revert to the old behavior if the `log` option is presented. 