### PR TITLE
force the same type as input image

### DIFF
--- a/racs_tools/convolve_uv.py
+++ b/racs_tools/convolve_uv.py
@@ -170,4 +170,6 @@ def smooth(
         log.warning(f"{np.isnan(newim).sum()} NaNs present in smoothed output")
 
     newim *= fac
-    return newim
+    
+    # Ensure the output data-type is the same as the input
+    return newim.astype(image.dtype)


### PR DESCRIPTION
Will attempt to ensure that the output data type matches the datatype of the input image. 