### PR TITLE
Refactor of beamcon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ mk_convolve
 beamlog.3d.astropy.txt
 beamlog.3d.robust.txt
 beamlog.3d.scipy.txt
+*.fits
+beamlog*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /tmp/numba_cache & chmod 777 /tmp/numba_cache & NUMBA_CACHE_DIR=/tmp/n
 ENV NUMBA_CACHE_DIR=/tmp/numba_cache
 COPY --chown=$MAMBA_USER:$MAMBA_USER . ./src
 RUN echo "Installing python and uv"
-RUN micromamba install python=3.8 uv -y -c conda-forge && \
+RUN micromamba install python=3.12 uv -y -c conda-forge && \
     micromamba clean --all --yes
 RUN echo "Installing RACS-tools"
 RUN micromamba run uv pip install ./src

--- a/Dockerfile.mpich
+++ b/Dockerfile.mpich
@@ -9,7 +9,7 @@ RUN mkdir /tmp/numba_cache & chmod 777 /tmp/numba_cache & NUMBA_CACHE_DIR=/tmp/n
 ENV NUMBA_CACHE_DIR=/tmp/numba_cache
 COPY --chown=$MAMBA_USER:$MAMBA_USER . ./src
 RUN echo "Installing python and uv"
-RUN micromamba install python=3.10 uv -y -c conda-forge && \
+RUN micromamba install python=3.12 uv -y -c conda-forge && \
     micromamba clean --all --yes
 RUN echo "Installing RACS-tools"
 RUN micromamba run uv pip install ./src[mpi]

--- a/README.md
+++ b/README.md
@@ -43,9 +43,14 @@ pip install git+https://github.com/AlecThomson/RACS-tools
 
 ```
 $ beamcon_2D -h
-usage: beamcon_2D [-h] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [-d] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [--log LOG] [--logfile LOGFILE] [-c CUTOFF] [--circularise] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores NCORES] infile [infile ...]
+usage: beamcon_2D [-h] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [-d] [--bmaj BMAJ] [--bmin BMIN]
+                  [--bpa BPA] [--log LOG] [--logfile LOGFILE] [-c CUTOFF] [--circularise] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores NCORES]
+                  [--executor {thread,process,mpi}]
+                  infile [infile ...]
 
-Smooth a field of 2D images to a common resolution. - Parallelisation can run using multiprocessing or MPI. - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the smallest common beam will be automatically computed. - Optionally, you can specify a target beam to use.
+Smooth a field of 2D images to a common resolution. - Parallelisation can run using multiprocessing or MPI. - Default names of output files are
+/path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the smallest common beam will be automatically computed. - Optionally, you can specify a
+target beam to use.
 
 positional arguments:
   infile                Input FITS image(s) to smooth (can be a wildcard) - beam info must be in header.
@@ -59,7 +64,9 @@ options:
   -o OUTDIR, --outdir OUTDIR
                         Output directory of smoothed FITS image(s) [same as input file]. (default: None)
   --conv_mode {robust,scipy,astropy,astropy_fft}
-                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with small convolving beams. (default: robust)
+                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can
+                        now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with
+                        small convolving beams. (default: robust)
   -v, --verbosity       Increase output verbosity (default: 0)
   -d, --dryrun          Compute common beam and stop [False]. (default: False)
   --bmaj BMAJ           Target BMAJ (arcsec) to convolve to [None]. (default: None)
@@ -77,23 +84,34 @@ options:
   -n NSAMPS, --nsamps NSAMPS
                         nsamps for radio_beam.commonbeam. (default: 200)
   --ncores NCORES       Number of cores to use for parallelisation. If None, use all available cores. (default: None)
+  --executor {thread,process,mpi}
+                        Executor to use for parallelisation (default: thread)
 ```
 
 ```
 $ beamcon_3D -h
-usage: beamcon_3D [-h] [--uselogs] [--mode MODE] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [--logfile LOGFILE] [-d] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [-c CUTOFF] [--circularise] [--ref_chan {first,last,mid}] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores NCORES] infile [infile ...]
+usage: beamcon_3D [-h] [--uselogs] [--mode MODE] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [--logfile LOGFILE] [-d] [-p PREFIX] [-s SUFFIX]
+                  [-o OUTDIR] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [-c CUTOFF] [--circularise] [--ref_chan {first,last,mid}] [-t TOLERANCE]
+                  [-e EPSILON] [-n NSAMPS] [--ncores NCORES] [--executor_type {thread,process,mpi}]
+                  infile [infile ...]
 
-Smooth a field of 3D cubes to a common resolution. - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the smallest common beam will be automatically computed. - Optionally, you can specify a target beam to use. - It is currently assumed that cubes will be 4D with a dummy Stokes axis. - Iterating over Stokes axis is not yet supported.
+Smooth a field of 3D cubes to a common resolution. - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the
+smallest common beam will be automatically computed. - Optionally, you can specify a target beam to use. - It is currently assumed that cubes will be
+4D with a dummy Stokes axis. - Iterating over Stokes axis is not yet supported.
 
 positional arguments:
-  infile                Input FITS image(s) to smooth (can be a wildcard) - CASA beamtable will be used if present i.e. if CASAMBM = T - Otherwise beam info must be in co-located beamlog files. - beamlog must have the name /path/to/beamlog{infile//.fits/.txt}
+  infile                Input FITS image(s) to smooth (can be a wildcard) - CASA beamtable will be used if present i.e. if CASAMBM = T - Otherwise beam
+                        info must be in co-located beamlog files. - beamlog must have the name /path/to/beamlog{infile//.fits/.txt}
 
 options:
   -h, --help            show this help message and exit
   --uselogs             Get convolving information from previous run [False]. (default: False)
-  --mode MODE           Common resolution mode [natural]. natural -- allow frequency variation. total -- smooth all plans to a common resolution. (default: natural)
+  --mode MODE           Common resolution mode [natural]. natural -- allow frequency variation. total -- smooth all plans to a common resolution.
+                        (default: natural)
   --conv_mode {robust,scipy,astropy,astropy_fft}
-                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with small convolving beams. (default: robust)
+                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can
+                        now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with
+                        small convolving beams. (default: robust)
   -v, --verbosity       Increase output verbosity (default: 0)
   --logfile LOGFILE     Save logging output to file (default: None)
   -d, --dryrun          Compute common beam and stop. (default: False)
@@ -110,7 +128,8 @@ options:
                         Cutoff BMAJ value (arcsec) -- Blank channels with BMAJ larger than this [None -- no limit] (default: None)
   --circularise         Circularise the final PSF -- Sets the BMIN = BMAJ, and BPA=0. (default: False)
   --ref_chan {first,last,mid}
-                        Reference psf for header [None]. first -- use psf for first frequency channel. last -- use psf for the last frequency channel. mid -- use psf for the centre frequency channel. Will use the CRPIX channel if not set. (default: None)
+                        Reference psf for header [None]. first -- use psf for first frequency channel. last -- use psf for the last frequency channel.
+                        mid -- use psf for the centre frequency channel. Will use the CRPIX channel if not set. (default: None)
   -t TOLERANCE, --tolerance TOLERANCE
                         tolerance for radio_beam.commonbeam. (default: 0.0001)
   -e EPSILON, --epsilon EPSILON
@@ -118,6 +137,8 @@ options:
   -n NSAMPS, --nsamps NSAMPS
                         nsamps for radio_beam.commonbeam. (default: 200)
   --ncores NCORES       Number of cores to use for parallelisation. If None, use all available cores. (default: None)
+  --executor_type {thread,process,mpi}
+                        Executor type for parallelisation. (default: thread)
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ options:
 
 If finding a common beam fails, try tweaking the `tolerance`, `epsilon`, and `nsamps` parameters. See [radio-beam](https://radio-beam.readthedocs.io/en/latest/) for more details.
 
+## Performance
+
+Profiling for `beamcon_3D` suggests this program requires a minimum of ~15X the memory of a data cube slice per process to perform convolution to a common beam. So for a 800 MB slice (e.g. typical POSSUM cube) you would want to allow 15 GB memory per worker (I use 20 GB). Choose `ncores` appropriately given your machine memory availability and this limit to ensure optimal performance with multiprocessing.
+
+An example slurm header for `beamcon_3D`:
+
+```
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=<ncores>
+#SBATCH --mem-per-cpu=20G
+```
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/README.md
+++ b/README.md
@@ -43,124 +43,81 @@ pip install git+https://github.com/AlecThomson/RACS-tools
 
 ```
 $ beamcon_2D -h
-usage: beamcon_2D [-h] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [-d] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [--log LOG] [--logfile LOGFILE] [-c CUTOFF] [--circularise] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores N_CORES | --mpi] infile [infile ...]
+usage: beamcon_2D [-h] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [-d] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [--log LOG] [--logfile LOGFILE] [-c CUTOFF] [--circularise] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores NCORES] infile [infile ...]
 
-    Smooth a field of 2D images to a common resolution.
-
-    - Parallelisation can run using multiprocessing or MPI.
-
-    - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits}
-
-    - By default, the smallest common beam will be automatically computed.
-    - Optionally, you can specify a target beam to use.
-
-
+Smooth a field of 2D images to a common resolution. - Parallelisation can run using multiprocessing or MPI. - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the smallest common beam will be automatically computed. - Optionally, you can specify a target beam to use.
 
 positional arguments:
   infile                Input FITS image(s) to smooth (can be a wildcard) - beam info must be in header.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -p PREFIX, --prefix PREFIX
-                        Add prefix to output filenames.
+                        Add prefix to output filenames. (default: None)
   -s SUFFIX, --suffix SUFFIX
-                        Add suffix to output filenames [sm].
+                        Add suffix to output filenames [sm]. (default: sm)
   -o OUTDIR, --outdir OUTDIR
-                        Output directory of smoothed FITS image(s) [same as input file].
+                        Output directory of smoothed FITS image(s) [same as input file]. (default: None)
   --conv_mode {robust,scipy,astropy,astropy_fft}
-                        Which method to use for convolution [robust].
-                                'robust' computes the analytic FT of the convolving Gaussian.
-                                Note this mode can now handle NaNs in the data.
-                                Can also be 'scipy', 'astropy', or 'astropy_fft'.
-                                Note these other methods cannot cope well with small convolving beams.
-
-  -v, --verbosity       Increase output verbosity
-  -d, --dryrun          Compute common beam and stop [False].
-  --bmaj BMAJ           Target BMAJ (arcsec) to convolve to [None].
-  --bmin BMIN           Target BMIN (arcsec) to convolve to [None].
-  --bpa BPA             Target BPA (deg) to convolve to [None].
-  --log LOG             Name of beamlog file. If provided, save beamlog data to a file [None - not saved].
-  --logfile LOGFILE     Save logging output to file
+                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with small convolving beams. (default: robust)
+  -v, --verbosity       Increase output verbosity (default: 0)
+  -d, --dryrun          Compute common beam and stop [False]. (default: False)
+  --bmaj BMAJ           Target BMAJ (arcsec) to convolve to [None]. (default: None)
+  --bmin BMIN           Target BMIN (arcsec) to convolve to [None]. (default: None)
+  --bpa BPA             Target BPA (deg) to convolve to [None]. (default: None)
+  --log LOG             Name of beamlog file. If provided, save beamlog data to a file [None - not saved]. (default: None)
+  --logfile LOGFILE     Save logging output to file (default: None)
   -c CUTOFF, --cutoff CUTOFF
-                        Cutoff BMAJ value (arcsec) -- Blank channels with BMAJ larger than this [None -- no limit]
-  --circularise         Circularise the final PSF -- Sets the BMIN = BMAJ, and BPA=0.
+                        Cutoff BMAJ value (arcsec) -- Blank channels with BMAJ larger than this [None -- no limit] (default: None)
+  --circularise         Circularise the final PSF -- Sets the BMIN = BMAJ, and BPA=0. (default: False)
   -t TOLERANCE, --tolerance TOLERANCE
-                        tolerance for radio_beam.commonbeam.
+                        tolerance for radio_beam.commonbeam. (default: 0.0001)
   -e EPSILON, --epsilon EPSILON
-                        epsilon for radio_beam.commonbeam.
+                        epsilon for radio_beam.commonbeam. (default: 0.0005)
   -n NSAMPS, --nsamps NSAMPS
-                        nsamps for radio_beam.commonbeam.
-  --ncores N_CORES      Number of processes (uses multiprocessing).
-  --mpi                 Run with MPI.
+                        nsamps for radio_beam.commonbeam. (default: 200)
+  --ncores NCORES       Number of cores to use for parallelisation. If None, use all available cores. (default: None)
 ```
 
 ```
 $ beamcon_3D -h
-usage: beamcon_3D [-h] [--uselogs] [--mode MODE] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [--logfile LOGFILE] [-d] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [-c CUTOFF] [--circularise] [--ref_chan {first,last,mid}] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] infile [infile ...]
+usage: beamcon_3D [-h] [--uselogs] [--mode MODE] [--conv_mode {robust,scipy,astropy,astropy_fft}] [-v] [--logfile LOGFILE] [-d] [-p PREFIX] [-s SUFFIX] [-o OUTDIR] [--bmaj BMAJ] [--bmin BMIN] [--bpa BPA] [-c CUTOFF] [--circularise] [--ref_chan {first,last,mid}] [-t TOLERANCE] [-e EPSILON] [-n NSAMPS] [--ncores NCORES] infile [infile ...]
 
-    Smooth a field of 3D cubes to a common resolution.
-
-    - Parallelisation is done using MPI.
-
-    - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits}
-
-    - By default, the smallest common beam will be automatically computed.
-    - Optionally, you can specify a target beam to use.
-
-    - It is currently assumed that cubes will be 4D with a dummy Stokes axis.
-    - Iterating over Stokes axis is not yet supported.
-
-
+Smooth a field of 3D cubes to a common resolution. - Default names of output files are /path/to/beamlog{infile//.fits/.{SUFFIX}.fits} - By default, the smallest common beam will be automatically computed. - Optionally, you can specify a target beam to use. - It is currently assumed that cubes will be 4D with a dummy Stokes axis. - Iterating over Stokes axis is not yet supported.
 
 positional arguments:
-  infile                Input FITS image(s) to smooth (can be a wildcard)
-                                - CASA beamtable will be used if present i.e. if CASAMBM = T
-                                - Otherwise beam info must be in co-located beamlog files.
-                                - beamlog must have the name /path/to/beamlog{infile//.fits/.txt}
+  infile                Input FITS image(s) to smooth (can be a wildcard) - CASA beamtable will be used if present i.e. if CASAMBM = T - Otherwise beam info must be in co-located beamlog files. - beamlog must have the name /path/to/beamlog{infile//.fits/.txt}
 
-
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --uselogs             Get convolving information from previous run [False].
-  --mode MODE           Common resolution mode [natural].
-                                natural -- allow frequency variation.
-                                total -- smooth all plans to a common resolution.
-
+  --uselogs             Get convolving information from previous run [False]. (default: False)
+  --mode MODE           Common resolution mode [natural]. natural -- allow frequency variation. total -- smooth all plans to a common resolution. (default: natural)
   --conv_mode {robust,scipy,astropy,astropy_fft}
-                        Which method to use for convolution [robust].
-                                'robust' computes the analytic FT of the convolving Gaussian.
-                                Note this mode can now handle NaNs in the data.
-                                Can also be 'scipy', 'astropy', or 'astropy_fft'.
-                                Note these other methods cannot cope well with small convolving beams.
-
-  -v, --verbosity       Increase output verbosity
-  --logfile LOGFILE     Save logging output to file
-  -d, --dryrun          Compute common beam and stop [False].
+                        Which method to use for convolution [robust]. 'robust' computes the analytic FT of the convolving Gaussian. Note this mode can now handle NaNs in the data. Can also be 'scipy', 'astropy', or 'astropy_fft'. Note these other methods cannot cope well with small convolving beams. (default: robust)
+  -v, --verbosity       Increase output verbosity (default: 0)
+  --logfile LOGFILE     Save logging output to file (default: None)
+  -d, --dryrun          Compute common beam and stop. (default: False)
   -p PREFIX, --prefix PREFIX
-                        Add prefix to output filenames.
+                        Add prefix to output filenames. (default: None)
   -s SUFFIX, --suffix SUFFIX
-                        Add suffix to output filenames [{MODE}].
+                        Add suffix to output filenames [{MODE}]. (default: None)
   -o OUTDIR, --outdir OUTDIR
-                        Output directory of smoothed FITS image(s) [None - same as input].
-  --bmaj BMAJ           BMAJ to convolve to [max BMAJ from given image(s)].
-  --bmin BMIN           BMIN to convolve to [max BMAJ from given image(s)].
-  --bpa BPA             BPA to convolve to [0].
+                        Output directory of smoothed FITS image(s) [None - same as input]. (default: None)
+  --bmaj BMAJ           BMAJ to convolve to [max BMAJ from given image(s)]. (default: None)
+  --bmin BMIN           BMIN to convolve to [max BMAJ from given image(s)]. (default: None)
+  --bpa BPA             BPA to convolve to [0]. (default: None)
   -c CUTOFF, --cutoff CUTOFF
-                        Cutoff BMAJ value (arcsec) -- Blank channels with BMAJ larger than this [None -- no limit]
-  --circularise         Circularise the final PSF -- Sets the BMIN = BMAJ, and BPA=0.
+                        Cutoff BMAJ value (arcsec) -- Blank channels with BMAJ larger than this [None -- no limit] (default: None)
+  --circularise         Circularise the final PSF -- Sets the BMIN = BMAJ, and BPA=0. (default: False)
   --ref_chan {first,last,mid}
-                        Reference psf for header [None].
-                                    first  -- use psf for first frequency channel.
-                                    last -- use psf for the last frequency channel.
-                                    mid -- use psf for the centre frequency channel.
-                                    Will use the CRPIX channel if not set.
-
+                        Reference psf for header [None]. first -- use psf for first frequency channel. last -- use psf for the last frequency channel. mid -- use psf for the centre frequency channel. Will use the CRPIX channel if not set. (default: None)
   -t TOLERANCE, --tolerance TOLERANCE
-                        tolerance for radio_beam.commonbeam.
+                        tolerance for radio_beam.commonbeam. (default: 0.0001)
   -e EPSILON, --epsilon EPSILON
-                        epsilon for radio_beam.commonbeam.
+                        epsilon for radio_beam.commonbeam. (default: 0.0005)
   -n NSAMPS, --nsamps NSAMPS
-                        nsamps for radio_beam.commonbeam.
+                        nsamps for radio_beam.commonbeam. (default: 200)
+  --ncores NCORES       Number of cores to use for parallelisation. If None, use all available cores. (default: None)
 ```
 
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -5,16 +5,14 @@ channels:
 - defaults
 - pkgw-forge
 dependencies:
-- python=3.8
+- python=3.10
 - pip
 - numpy
 - scipy
 - astropy
-- gfortran
 - mpi4py
 - pip:
   - spectral_cube
   - radio_beam
-  - schwimmbad
   - tqdm
   - ./

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ numba = "*"
 black = "*"
 isort = "*"
 
-[tool.poetry.extras]
-mpi = ["mpi4py"]
 
 [tool.poetry.scripts]
 beamcon_2D = "racs_tools.beamcon_2D:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "racs-tools"
-version = "3.0.5"
+version = "4.0.0"
 description = "Useful scripts for RACS."
 authors = ["Alec Thomson"]
 license = "BSD"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,10 @@ python = ">=3.8"
 numpy = "<2"
 astropy = ">=5"
 radio_beam = "*"
-schwimmbad = "*"
 scipy = "*"
 spectral_cube = ">=0.6.3"
 tqdm = "*"
 numba = "*"
-mpi4py = {version = "*", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,14 @@ scipy = "*"
 spectral_cube = ">=0.6.3"
 tqdm = "*"
 numba = "*"
+mpi4py = {version = ">=3", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = "*"
 isort = "*"
 
+[tool.poetry.extras]
+mpi = ["mpi4py"]
 
 [tool.poetry.scripts]
 beamcon_2D = "racs_tools.beamcon_2D:cli"

--- a/racs_tools/au2.py
+++ b/racs_tools/au2.py
@@ -162,6 +162,6 @@ def gauss_factor(
         * bmin2
         / math.sqrt(alpha * beta - 0.25 * gamma * gamma)
     )
-    fac = ((math.sqrt(dx1**2) * math.sqrt(dy1**2))) / amp
+    fac = (math.sqrt(dx1**2) * math.sqrt(dy1**2)) / amp
 
     return fac, amp, bmaj, bmin, np.degrees(bpa)

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -3,15 +3,11 @@
 __author__ = "Alec Thomson"
 
 import logging
-import os
-import sys
-from functools import partial
-from hashlib import new
-from typing import Dict, List, Optional, Tuple
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import List, Literal, NamedTuple, Optional, Tuple
 
-import astropy.wcs
 import numpy as np
-import schwimmbad
 from astropy import units as u
 from astropy.io import ascii, fits
 from astropy.table import Table
@@ -21,8 +17,14 @@ from radio_beam import Beam, Beams
 from radio_beam.utils import BeamError
 from tqdm import tqdm
 
-from racs_tools import au2
-from racs_tools.convolve_uv import smooth
+from racs_tools.convolve_uv import (
+    get_convolving_beam,
+    get_nyquist_beam,
+    my_ceil,
+    parse_conv_mode,
+    round_up,
+    smooth,
+)
 from racs_tools.logging import logger, setup_logger
 
 #############################################
@@ -30,120 +32,82 @@ from racs_tools.logging import logger, setup_logger
 #############################################
 
 
-def round_up(n: float, decimals: int = 0) -> float:
-    """Round to number of decimals
-
-    Args:
-        n (float): Number to round.
-        decimals (int, optional): Number of decimals. Defaults to 0.
-
-    Returns:
-        float: Rounded number.
-    """
-    multiplier = 10**decimals
-    return np.ceil(n * multiplier) / multiplier
-
-
-def my_ceil(a: float, precision: float = 0.0) -> float:
-    """Modified ceil function to round up to precision
-
-    Args:
-        a (float): Number to round.
-        precision (float, optional): Precision of rounding. Defaults to 0.
-
-    Returns:
-        float: Rounded number.
-    """
-    return np.round(a + 0.5 * 10 ** (-precision), precision)
-
-
-def getbeam(
-    old_beam: Beam,
-    new_beam: Beam,
-    dx: u.Quantity,
-    dy: u.Quantity,
+def check_target_beam(
+    target_beam: Beam,
+    all_beams: Beams,
+    files: List[Path],
     cutoff: Optional[float] = None,
-) -> Tuple[Beam, float]:
-    """Get the beam to use for smoothing
-
-    Args:
-        old_beam (Beam): Current beam.
-        new_beam (Beam): Target beam.
-        dx (u.Quantity): Pixel size in x.
-        dy (u.Quantity): Pixel size in y.
-        cutoff (float, optional): Cutoff for beamsize in arcsec. Defaults to None.
-
-    Raises:
-        err: If beam deconvolution fails.
-
-    Returns:
-        Tuple[Beam, float]: Convolving beam and scaling factor.
-    """
-    logger.info(f"Current beam is {old_beam!r}")
-
-    if cutoff is not None and old_beam.major.to(u.arcsec) > cutoff * u.arcsec:
-        return (
-            Beam(
-                major=np.nan * u.deg,
-                minor=np.nan * u.deg,
-                pa=np.nan * u.deg,
-            ),
-            np.nan,
+):
+    logger.info("Checking that target beam will deconvolve...")
+    mask_count = 0
+    failed = []
+    for i, (beam, file) in enumerate(
+        tqdm(
+            zip(all_beams, files),
+            total=len(all_beams),
+            desc="Deconvolving",
+            disable=(logger.level > logging.INFO),
         )
+    ):
+        if cutoff is not None and beam.major.to(u.arcsec) > cutoff * u.arcsec:
+            continue
+        try:
+            target_beam.deconvolve(beam)
+        except ValueError:
+            mask_count += 1
+            failed.append(file)
+        except BeamError as be:
+            # BeamError should not be raised if beams are equal
+            if target_beam != beam:
+                raise BeamError(be)
+    is_good = mask_count == 0
+    if not is_good:
+        logger.error("The following images could not reach target resolution:")
+        logger.error(failed)
 
-    if new_beam == old_beam:
-        conbm = Beam(
-            major=0 * u.deg,
-            minor=0 * u.deg,
-            pa=0 * u.deg,
-        )
-        fac = 1.0
-        logger.warning(
-            f"New beam {new_beam!r} and old beam {old_beam!r} are the same. Won't attempt convolution."
-        )
-        return conbm, fac
-    try:
-        conbm = new_beam.deconvolve(old_beam)
-    except BeamError as err:
-        logger.error(err)
-        logger.warning(
-            f"Could not deconvolve. New: {new_beam!r}, Old: {old_beam!r} - will set convolving beam to 0.0"
-        )
-        conbm = new_beam.deconvolve(old_beam, failure_returns_pointlike=True)
-    fac, amp, outbmaj, outbmin, outbpa = au2.gauss_factor(
-        beamConv=[
-            conbm.major.to(u.arcsec).value,
-            conbm.minor.to(u.arcsec).value,
-            conbm.pa.to(u.deg).value,
-        ],
-        beamOrig=[
-            old_beam.major.to(u.arcsec).value,
-            old_beam.minor.to(u.arcsec).value,
-            old_beam.pa.to(u.deg).value,
-        ],
-        dx1=dx.to(u.arcsec).value,
-        dy1=dy.to(u.arcsec).value,
-    )
-
-    return conbm, fac
+    return is_good
 
 
-def getimdata(cubenm: str) -> dict:
+class ImageData(NamedTuple):
+    """Image data and metadata"""
+
+    filename: Path
+    """Filename of FITS file"""
+    image: np.ndarray
+    """Image data"""
+    four_d: bool
+    """Does the image have spectral and polarization axes?"""
+    header: fits.Header
+    """FITS header"""
+    old_beam: Beam
+    """Original beam"""
+    nx: int
+    """Number of pixels in x"""
+    ny: int
+    """Number of pixels in y"""
+    dx: u.Quantity
+    """Pixel size in x"""
+    dy: u.Quantity
+    """Pixel size in y"""
+
+
+def getimdata(cubenm: Path) -> ImageData:
     """Get image data from FITS file
 
     Args:
-        cubenm (str): File name of image.
+        cubenm (Path): File name of image.
 
     Returns:
-        dict: Data and metadata.
+        ImageData: Data and metadata.
     """
     logger.info(f"Getting image data from {cubenm}")
     with fits.open(cubenm, memmap=True, mode="denywrite") as hdu:
-        w = astropy.wcs.WCS(hdu[0])
-        pixelscales = proj_plane_pixel_scales(w)
+        header = hdu[0].header
+        wcs = WCS(hdu[0])
+        pixelscales = proj_plane_pixel_scales(wcs)
 
-        dxas = pixelscales[0] * u.deg
-        dyas = pixelscales[1] * u.deg
+        dx = pixelscales[0] * u.deg
+        dy = pixelscales[1] * u.deg
 
         if len(hdu[0].data.shape) == 4:
             # has spectral, polarization axes
@@ -153,27 +117,25 @@ def getimdata(cubenm: str) -> dict:
         nx, ny = data.shape[-1], data.shape[-2]
 
         old_beam = Beam.from_fits_header(hdu[0].header)
-
-        datadict = {
-            "filename": os.path.basename(cubenm),
-            "image": data,
-            "4d": (len(hdu[0].data.shape) == 4),
-            "header": hdu[0].header,
-            "old_beam": old_beam,
-            "nx": nx,
-            "ny": ny,
-            "dx": dxas,
-            "dy": dyas,
-        }
-    return datadict
+        is_4d = len(hdu[0].data.shape) == 4
+    return ImageData(
+        filename=Path(cubenm),
+        image=data,
+        four_d=is_4d,
+        header=header,
+        old_beam=old_beam,
+        nx=nx,
+        ny=ny,
+        dx=dx,
+        dy=dy,
+    )
 
 
 def savefile(
     newimage: np.ndarray,
-    filename: str,
+    outfile: Path,
     header: fits.Header,
-    final_beam: Beam,
-    outdir: str = ".",
+    new_beam: Beam,
 ) -> None:
     """Save smoothed image to FITS file
 
@@ -181,23 +143,35 @@ def savefile(
         newimage (np.ndarray): Smoothed image.
         filename (str): File name.
         header (fits.Header): FITS header.
-        final_beam (Beam): New beam.
+        new_beam (Beam): New beam.
         outdir (str, optional): Output directory. Defaults to ".".
     """
-    outfile = f"{outdir}/{filename}"
     logger.info(f"Saving to {outfile}")
-    beam = final_beam
+    beam = new_beam
     header = beam.attach_to_header(header)
     fits.writeto(outfile, newimage.astype(np.float32), header=header, overwrite=True)
 
 
-def worker(
-    file: str,
-    outdir: str,
+class BeamLogInfo(NamedTuple):
+    """Beam log info"""
+
+    filename: Path
+    """Filename of FITS file"""
+    old_beam: Beam
+    """Original beam"""
+    new_beam: Beam
+    """Target beam"""
+    conv_beam: Beam
+    """Convolving beam"""
+
+
+def beamcon_2d_on_fits(
+    file: Path,
     new_beam: Beam,
     conv_mode: str,
     suffix: str = "",
     prefix: str = "",
+    outdir: Optional[Path] = None,
     cutoff: Optional[float] = None,
     dryrun: bool = False,
 ) -> dict:
@@ -218,70 +192,67 @@ def worker(
     """
     logger.info(f"Working on {file}")
 
-    if outdir is None:
-        outdir = os.path.dirname(file)
+    outfile = Path(file.name)
+    if suffix:
+        outfile = outfile.with_suffix(f".{suffix}.fits")
+    if prefix:
+        outfile = Path(prefix + outfile.name)
 
-    if outdir == "":
-        outdir = "."
+    if outdir is not None:
+        outdir = outdir.absolute()
+    else:
+        outdir = file.parent
 
-    outfile = os.path.basename(file)
-    outfile = outfile.replace(".fits", "") + f".{suffix}.fits"
-    if prefix is not None:
-        outfile = prefix + outfile
-    datadict = getimdata(file)
+    image_data = getimdata(file)
 
-    conbeam, sfactor = getbeam(
-        old_beam=datadict["old_beam"],
+    conv_beam, _ = get_convolving_beam(
+        old_beam=image_data.old_beam,
         new_beam=new_beam,
-        dx=datadict["dx"],
-        dy=datadict["dy"],
+        dx=image_data.dx,
+        dy=image_data.dy,
         cutoff=cutoff,
     )
 
-    datadict.update({"conbeam": conbeam, "final_beam": new_beam, "sfactor": sfactor})
-    if not dryrun:
-        if np.isnan(sfactor) or np.isnan(conbeam):
-            logger.warning(f"Setting {outfile} to NaN")
-            newim = datadict["image"] * np.nan
-        elif (
-            conbeam == Beam(major=0 * u.deg, minor=0 * u.deg, pa=0 * u.deg)
-            and sfactor == 1
-        ):
-            newim = datadict["image"]
-        else:
-            newim = smooth(
-                image=datadict["image"],
-                old_beam=datadict["old_beam"],
-                final_beam=datadict["final_beam"],
-                dx=datadict["dx"],
-                dy=datadict["dy"],
-                sfactor=datadict["sfactor"],
-                conbeam=datadict["conbeam"],
-                conv_mode=conv_mode,
-            )
-        if datadict["4d"]:
-            # make it back into a 4D image
-            newim = np.expand_dims(np.expand_dims(newim, axis=0), axis=0)
-        datadict.update(
-            {
-                "newimage": newim,
-            }
-        )
-        savefile(
-            newimage=datadict["newimage"],
+    if dryrun:
+        return BeamLogInfo(
             filename=outfile,
-            header=datadict["header"],
-            final_beam=datadict["final_beam"],
-            outdir=outdir,
+            old_beam=image_data.old_beam,
+            new_beam=new_beam,
+            conv_beam=conv_beam,
         )
 
-    return datadict
+    new_image = smooth(
+        image=image_data.image,
+        old_beam=image_data.old_beam,
+        new_beam=new_beam,
+        dx=image_data.dx,
+        dy=image_data.dy,
+        conv_mode=conv_mode,
+        cutoff=cutoff,
+    )
+    if image_data.four_d:
+        # make it back into a 4D image
+        new_image = np.expand_dims(np.expand_dims(new_image, axis=0), axis=0)
+
+    savefile(
+        newimage=new_image,
+        outfile=outdir / outfile,
+        header=image_data.header,
+        new_beam=new_beam,
+    )
+
+    return BeamLogInfo(
+        filename=outfile,
+        old_beam=image_data.old_beam,
+        new_beam=new_beam,
+        conv_beam=conv_beam,
+    )
 
 
-def getmaxbeam(
+def get_common_beam(
     files: List[str],
     conv_mode: str = "robust",
-    target_beam: Beam = None,
+    target_beam: Optional[Beam] = None,
     cutoff: Optional[float] = None,
     tolerance: float = 0.0001,
     nsamps: float = 200,
@@ -335,82 +306,33 @@ def getmaxbeam(
     if target_beam is None:
         # Find the common beam
         try:
-            cmn_beam = beams[~flags].common_beam(
+            target_beam = beams[~flags].common_beam(
                 tolerance=tolerance, epsilon=epsilon, nsamps=nsamps
             )
         except BeamError:
             logger.warning(
                 "Couldn't find common beam with defaults\nTrying again with smaller tolerance"
             )
-            cmn_beam = beams[~flags].common_beam(
+            target_beam = beams[~flags].common_beam(
                 tolerance=tolerance * 0.1, epsilon=epsilon, nsamps=nsamps
             )
 
         # Round up values
-        cmn_beam = Beam(
-            major=my_ceil(cmn_beam.major.to(u.arcsec).value, precision=1) * u.arcsec,
-            minor=my_ceil(cmn_beam.minor.to(u.arcsec).value, precision=1) * u.arcsec,
-            pa=round_up(cmn_beam.pa.to(u.deg), decimals=2),
+        target_beam = Beam(
+            major=my_ceil(target_beam.major.to(u.arcsec).value, precision=1) * u.arcsec,
+            minor=my_ceil(target_beam.minor.to(u.arcsec).value, precision=1) * u.arcsec,
+            pa=round_up(target_beam.pa.to(u.deg), decimals=2),
         )
 
-    else:
-        cmn_beam = target_beam
-
-    target_header = header
-    w = WCS(target_header)
-    pixelscales = proj_plane_pixel_scales(w)
-
-    dx = pixelscales[0] * u.deg
-    dy = pixelscales[1] * u.deg
-    if not np.isclose(dx, dy):
-        raise Exception("GRID MUST BE SAME IN X AND Y")
-    grid = dy
     if conv_mode != "robust":
-        # Get the minor axis of the convolving beams
-        minorcons = []
-        for beam in beams:
-            try:
-                minorcons += [cmn_beam.deconvolve(beam).minor.to(u.arcsec).value]
-            except BeamError as err:
-                logger.error(err)
-                logger.warning(
-                    f"Could not deconvolve. New: {cmn_beam!r}, Old: {beam!r} - will set convolving beam to 0.0"
-                )
-                minorcons += [
-                    cmn_beam.deconvolve(beam, failure_returns_pointlike=True)
-                    .minor.to(u.arcsec)
-                    .value
-                ]
-        minorcons = np.array(minorcons) * u.arcsec
-        samps = minorcons / grid.to(u.arcsec)
-        # Check that convolving beam will be Nyquist sampled
-        if any(samps.value < 2):
-            # Set the convolving beam to be Nyquist sampled
-            nyq_con_beam = Beam(major=grid * 2, minor=grid * 2, pa=0 * u.deg)
-            # Find new target based on common beam * Nyquist beam
-            # Not sure if this is best - but it works
-            nyq_beam = cmn_beam.convolve(nyq_con_beam)
-            nyq_beam = Beam(
-                major=my_ceil(nyq_beam.major.to(u.arcsec).value, precision=1)
-                * u.arcsec,
-                minor=my_ceil(nyq_beam.minor.to(u.arcsec).value, precision=1)
-                * u.arcsec,
-                pa=round_up(nyq_beam.pa.to(u.deg), decimals=2),
-            )
-            logger.info(f"Smallest common Nyquist sampled beam is: {nyq_beam!r}")
-            if target_beam is not None:
-                if target_beam < nyq_beam:
-                    logger.warning("TARGET BEAM WILL BE UNDERSAMPLED!")
-                    raise Exception("CAN'T UNDERSAMPLE BEAM - EXITING")
-            else:
-                logger.warning("COMMON BEAM WILL BE UNDERSAMPLED!")
-                logger.warning("SETTING COMMON BEAM TO NYQUIST BEAM")
-                cmn_beam = nyq_beam
+        target_beam = get_nyquist_beam(
+            target_beam=target_beam, target_header=header, beams=beams
+        )
 
-    return cmn_beam, beams
+    return target_beam, beams
 
 
-def writelog(output: List[Dict], commonbeam_log: str):
+def writelog(output: List[BeamLogInfo], commonbeam_log: str):
     """Write beamlog file.
 
     Args:
@@ -434,28 +356,28 @@ def writelog(output: List[Dict], commonbeam_log: str):
     )
     # Target
     commonbeam_tab.add_column(
-        [out["final_beam"].major.to(u.deg).value for out in output] * u.deg,
+        [out["new_beam"].major.to(u.deg).value for out in output] * u.deg,
         name="Target BMAJ",
     )
     commonbeam_tab.add_column(
-        [out["final_beam"].minor.to(u.deg).value for out in output] * u.deg,
+        [out["new_beam"].minor.to(u.deg).value for out in output] * u.deg,
         name="Target BMIN",
     )
     commonbeam_tab.add_column(
-        [out["final_beam"].pa.to(u.deg).value for out in output] * u.deg,
+        [out["new_beam"].pa.to(u.deg).value for out in output] * u.deg,
         name="Target BPA",
     )
     # Convolving
     commonbeam_tab.add_column(
-        [out["conbeam"].major.to(u.deg).value for out in output] * u.deg,
+        [out["conv_beam"].major.to(u.deg).value for out in output] * u.deg,
         name="Convolving BMAJ",
     )
     commonbeam_tab.add_column(
-        [out["conbeam"].minor.to(u.deg).value for out in output] * u.deg,
+        [out["conv_beam"].minor.to(u.deg).value for out in output] * u.deg,
         name="Convolving BMIN",
     )
     commonbeam_tab.add_column(
-        [out["conbeam"].pa.to(u.deg).value for out in output] * u.deg,
+        [out["conv_beam"].pa.to(u.deg).value for out in output] * u.deg,
         name="Convolving BPA",
     )
 
@@ -472,13 +394,12 @@ def writelog(output: List[Dict], commonbeam_log: str):
     logger.info(f"Convolving log written to {commonbeam_log}")
 
 
-def main(
-    pool,
-    infile: list = [],
+def smooth_fits_files(
+    infile_list: List[Path] = [],
     prefix: Optional[str] = None,
     suffix: Optional[str] = None,
-    outdir: Optional[str] = None,
-    conv_mode: str = "robust",
+    outdir: Optional[Path] = None,
+    conv_mode: Literal["robust", "scipy", "astropy", "astropy_fft"] = "robust",
     dryrun: bool = False,
     bmaj: Optional[float] = None,
     bmin: Optional[float] = None,
@@ -520,42 +441,25 @@ def main(
 
     if dryrun:
         logger.info("Doing a dry run -- no files will be saved")
-    # Fix up outdir
-    if outdir is not None:
-        outdir = os.path.abspath(outdir)
 
     # Get file list
-    files = sorted(infile)
-    if files == []:
-        raise Exception("No files found!")
+    files = sorted(infile_list)
+    if len(files) == 0:
+        raise FileNotFoundError("No files found!")
 
-    # Parse args
-    logger.info(f"Convolution mode: {conv_mode}")
-    if not conv_mode in ["robust", "scipy", "astropy", "astropy_fft"]:
-        raise Exception("Please select valid convolution method!")
+    conv_mode = parse_conv_mode(conv_mode)
 
-    logger.info(f"Using convolution method {conv_mode}")
-    if conv_mode == "robust":
-        logger.info("This is the most robust method. And fast!")
-    elif conv_mode == "scipy":
-        logger.info("This fast, but not robust to NaNs or small PSF changes")
-    else:
-        logger.info("This is slower, but robust to NaNs, but not to small PSF changes")
-
-    nonetest = [test is None for test in [bmaj, bmin, bpa]]
-
+    nonetest = [param is None for param in (bmaj, bmin, bpa)]
     if all(nonetest):
         target_beam = None
-
-    elif not all(nonetest) and any(nonetest):
+    elif any(nonetest):
         raise Exception("Please specify all target beam params!")
-
-    elif not all(nonetest) and not any(nonetest):
+    else:
         target_beam = Beam(bmaj * u.arcsec, bmin * u.arcsec, bpa * u.deg)
         logger.info(f"Target beam is {target_beam!r}")
 
     # Find smallest common beam
-    big_beam, allbeams = getmaxbeam(
+    common_beam, all_beams = get_common_beam(
         files,
         conv_mode=conv_mode,
         target_beam=target_beam,
@@ -566,72 +470,43 @@ def main(
     )
 
     if target_beam is not None:
-        logger.info("Checking that target beam will deconvolve...")
+        if not check_target_beam(target_beam, all_beams, files, cutoff):
+            raise BeamError("Please choose a larger target beam!")
 
-        mask_count = 0
-        failed = []
-        for i, (beam, file) in enumerate(
-            tqdm(
-                zip(allbeams, files),
-                total=len(allbeams),
-                desc="Deconvolving",
-                disable=(logger.level > logging.INFO),
-            )
-        ):
-            if cutoff is not None and beam.major.to(u.arcsec) > cutoff * u.arcsec:
-                continue
-            try:
-                target_beam.deconvolve(beam)
-            except ValueError:
-                mask_count += 1
-                failed.append(file)
-            except BeamError as be:
-                # BeamError should not be raised if beams are equal
-                if target_beam != beam:
-                    raise BeamError(be)
-        if mask_count > 0:
-            logger.warning("The following images could not reach target resolution:")
-            logger.warning(failed)
-
-            raise Exception("Please choose a larger target beam!")
-
-        else:
-            new_beam = target_beam
-
-    else:
-        new_beam = big_beam
+        common_beam = target_beam
 
     if circularise:
         logger.info("Circular beam requested, setting BMIN=BMAJ and BPA=0")
-        new_beam = Beam(
-            major=new_beam.major,
-            minor=new_beam.major,
+        common_beam = Beam(
+            major=common_beam.major,
+            minor=common_beam.major,
             pa=0 * u.deg,
         )
 
-    logger.info(f"Final beam is {new_beam!r}")
+    logger.info(f"Final beam is {common_beam!r}")
 
-    output = list(
-        pool.map(
-            partial(
-                worker,
+    with ThreadPoolExecutor() as executor:
+        futures = []
+        for file in files:
+            future = executor.submit(
+                beamcon_2d_on_fits,
+                file=file,
                 outdir=outdir,
-                new_beam=new_beam,
+                new_beam=common_beam,
                 conv_mode=conv_mode,
                 suffix=suffix,
                 prefix=prefix,
                 cutoff=cutoff,
                 dryrun=dryrun,
-            ),
-            files,
-        )
-    )
+            )
+            futures.append(future)
 
+    beam_log_list = [future.result() for future in futures]
     if log is not None:
-        writelog(output, log)
+        writelog(beam_log_list, log)
 
     logger.info("Done!")
-    return new_beam
+    return common_beam
 
 
 def cli():
@@ -659,7 +534,7 @@ def cli():
     parser.add_argument(
         "infile",
         metavar="infile",
-        type=str,
+        type=Path,
         help="Input FITS image(s) to smooth (can be a wildcard) - beam info must be in header.",
         nargs="+",
     )
@@ -686,7 +561,7 @@ def cli():
         "-o",
         "--outdir",
         dest="outdir",
-        type=str,
+        type=Path,
         default=None,
         help="Output directory of smoothed FITS image(s) [same as input file].",
     )
@@ -798,41 +673,33 @@ def cli():
         help="nsamps for radio_beam.commonbeam.",
     )
 
-    group = parser.add_mutually_exclusive_group()
-
-    group.add_argument(
-        "--ncores",
-        dest="n_cores",
-        default=1,
-        type=int,
-        help="Number of processes (uses multiprocessing).",
-    )
-    group.add_argument(
-        "--mpi", dest="mpi", default=False, action="store_true", help="Run with MPI."
-    )
-
     args = parser.parse_args()
-    # Set up logging
+
+    nonetest = [param is None for param in (args.bmaj, args.bmin, args.bpa)]
+    if not all(nonetest) and any(nonetest):
+        parser.error("Please specify all target beam params!")
+
     logger = setup_logger(
         verbosity=args.verbosity,
         filename=args.logfile,
     )
-
-    pool = schwimmbad.choose_pool(mpi=args.mpi, processes=args.n_cores)
-    if args.mpi:
-        if not pool.is_master():
-            pool.wait()
-            sys.exit(0)
-
-    arg_dict = vars(args)
-    # pop unwanted arguments
-    _ = arg_dict.pop("mpi")
-    _ = arg_dict.pop("n_cores")
-    _ = arg_dict.pop("verbosity")
-    _ = arg_dict.pop("logfile")
-
-    _ = main(pool, **arg_dict)
-    pool.close()
+    _ = smooth_fits_files(
+        infile_list=args.infile,
+        prefix=args.prefix,
+        suffix=args.suffix,
+        outdir=args.outdir,
+        conv_mode=args.conv_mode,
+        dryrun=args.dryrun,
+        bmaj=args.bmaj,
+        bmin=args.bmin,
+        bpa=args.bpa,
+        log=args.log,
+        circularise=args.circularise,
+        cutoff=args.cutoff,
+        tolerance=args.tolerance,
+        nsamps=args.nsamps,
+        epsilon=args.epsilon,
+    )
 
 
 if __name__ == "__main__":

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -483,7 +483,7 @@ def smooth_fits_files(
     if listfile:
         assert len(infile_list) == 1, "Only one list file can be provided!"
         with open(infile_list[0]) as f:
-            infile_list = [Path(l) for l in f.read().splitlines()]
+            infile_list = [Path(line) for line in f.read().splitlines()]
     files = sorted(infile_list)
     if len(files) == 0:
         raise FileNotFoundError("No files found!")

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -146,10 +146,12 @@ def savefile(
         new_beam (Beam): New beam.
         outdir (str, optional): Output directory. Defaults to ".".
     """
-    logger.info(f"Saving to {outfile}")
+    logger.info(f"Saving to {outfile.absolute()}")
     beam = new_beam
     header = beam.attach_to_header(header)
-    fits.writeto(outfile, newimage.astype(np.float32), header=header, overwrite=True)
+    fits.writeto(
+        outfile.absolute(), newimage.astype(np.float32), header=header, overwrite=True
+    )
 
     assert outfile.exists(), f"File {outfile} not saved!"
 
@@ -203,7 +205,7 @@ def beamcon_2d_on_fits(
     if outdir is not None:
         outdir = outdir.absolute()
     else:
-        outdir = file.parent
+        outdir = file.parent.absolute()
 
     image_data = getimdata(file)
 

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -2,6 +2,7 @@
 """ Convolve ASKAP images to common resolution """
 __author__ = "Alec Thomson"
 
+import gc
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -250,6 +251,7 @@ def beamcon_2d_on_fits(
         conv_mode=conv_mode,
         cutoff=cutoff,
     )
+
     if image_data.four_d:
         # make it back into a 4D image
         new_image = np.expand_dims(np.expand_dims(new_image, axis=0), axis=0)
@@ -260,6 +262,8 @@ def beamcon_2d_on_fits(
         header=image_data.header,
         new_beam=new_beam,
     )
+    del new_image
+    gc.collect()
 
     return BeamLogInfo(
         filename=outfile,

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -708,6 +708,14 @@ def cli():
         help="Number of cores to use for parallelisation. If None, use all available cores.",
     )
 
+    parser.add_argument(
+        "--executor",
+        type=str,
+        choices=["thread", "process", "mpi"],
+        default="thread",
+        help="Executor to use for parallelisation",
+    )
+
     args = parser.parse_args()
 
     nonetest = [param is None for param in (args.bmaj, args.bmin, args.bpa)]
@@ -735,6 +743,7 @@ def cli():
         nsamps=args.nsamps,
         epsilon=args.epsilon,
         ncores=args.ncores,
+        executor_type=args.executor,
     )
 
 

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -414,6 +414,7 @@ def smooth_fits_files(
     tolerance: float = 0.0001,
     nsamps: int = 200,
     epsilon: float = 0.0005,
+    ncores: Optional[int] = None,
 ):
     """Main script.
 
@@ -489,7 +490,9 @@ def smooth_fits_files(
 
     logger.info(f"Final beam is {common_beam!r}")
 
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(
+        max_workers=ncores,
+    ) as executor:
         futures = []
         for file in files:
             future = executor.submit(
@@ -532,7 +535,7 @@ def cli():
 
     # Parse the command line options
     parser = argparse.ArgumentParser(
-        description=descStr, formatter_class=argparse.RawTextHelpFormatter
+        description=descStr, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument(
@@ -677,6 +680,13 @@ def cli():
         help="nsamps for radio_beam.commonbeam.",
     )
 
+    parser.add_argument(
+        "--ncores",
+        type=int,
+        default=None,
+        help="Number of cores to use for parallelisation. If None, use all available cores.",
+    )
+
     args = parser.parse_args()
 
     nonetest = [param is None for param in (args.bmaj, args.bmin, args.bpa)]
@@ -703,6 +713,7 @@ def cli():
         tolerance=args.tolerance,
         nsamps=args.nsamps,
         epsilon=args.epsilon,
+        ncores=args.ncores,
     )
 
 

--- a/racs_tools/beamcon_2D.py
+++ b/racs_tools/beamcon_2D.py
@@ -151,6 +151,8 @@ def savefile(
     header = beam.attach_to_header(header)
     fits.writeto(outfile, newimage.astype(np.float32), header=header, overwrite=True)
 
+    assert outfile.exists(), f"File {outfile} not saved!"
+
 
 class BeamLogInfo(NamedTuple):
     """Beam log info"""

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1040,7 +1040,7 @@ def smooth_fits_cube(
     logger.info(f"Mode is {mode}")
     if mode == "natural":
         logger.info("Smoothing each channel to a common resolution")
-    if mode == "total":
+    elif mode == "total":
         logger.info("Smoothing all channels to a common resolution")
     else:
         raise Exception(f"Mode must be 'natural' or 'total', not '{mode}'")

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1277,6 +1277,14 @@ def cli():
         help="Number of cores to use for parallelisation. If None, use all available cores.",
     )
 
+    parser.add_argument(
+        "--executor_type",
+        type=str,
+        default="thread",
+        choices=["thread", "process", "mpi"],
+        help="Executor type for parallelisation.",
+    )
+
     args = parser.parse_args()
 
     # Set up logging
@@ -1303,6 +1311,7 @@ def cli():
         tolerance=args.tolerance,
         epsilon=args.epsilon,
         ncores=args.ncores,
+        nsamps=args.nsamps,
     )
 
 

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -3,13 +3,11 @@
 __author__ = "Alec Thomson"
 
 import logging
-import os
-import stat
 import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Tuple
+from typing import List, Literal, NamedTuple, Optional
 
 import numpy as np
 from astropy import units as u
@@ -36,89 +34,6 @@ warnings.filterwarnings("ignore", message="invalid value encountered in true_div
 #############################################
 #### ADAPTED FROM SCRIPT BY T. VERNSTROM ####
 #############################################
-
-
-class Error(OSError):
-    pass
-
-
-class SameFileError(Error):
-    """Raised when source and destination are the same file."""
-
-
-class SpecialFileError(OSError):
-    """Raised when trying to do a kind of operation (e.g. copying) which is
-    not supported on a special file (e.g. a named pipe)"""
-
-
-class ExecError(OSError):
-    """Raised when a command could not be executed"""
-
-
-class ReadError(OSError):
-    """Raised when an archive cannot be read"""
-
-
-class RegistryError(Exception):
-    """Raised when a registry operation with the archiving
-    and unpacking registeries fails"""
-
-
-def _samefile(src, dst):
-    # Macintosh, Unix.
-    if hasattr(os.path, "samefile"):
-        try:
-            return os.path.samefile(src, dst)
-        except OSError:
-            return False
-
-
-def copyfile(src, dst, *, follow_symlinks=True):
-    """Copy data from src to dst.
-
-    If follow_symlinks is not set and src is a symbolic link, a new
-    symlink will be created instead of copying the file it points to.
-
-    """
-    if _samefile(src, dst):
-        raise SameFileError(f"{src!r} and {dst!r} are the same file")
-
-    for fn in [src, dst]:
-        try:
-            st = os.stat(fn)
-        except OSError:
-            # File most likely does not exist
-            pass
-        else:
-            # XXX What about other special files? (sockets, devices...)
-            if stat.S_ISFIFO(st.st_mode):
-                raise SpecialFileError("`%s` is a named pipe" % fn)
-
-    if not follow_symlinks and os.path.islink(src):
-        os.symlink(os.readlink(src), dst)
-    else:
-        with open(src, "rb") as fsrc:
-            with open(dst, "wb") as fdst:
-                copyfileobj(fsrc, fdst)
-    return dst
-
-
-def copyfileobj(fsrc, fdst, length=16 * 1024):
-    # copied = 0
-    total = os.fstat(fsrc.fileno()).st_size
-    with tqdm(
-        total=total,
-        disable=(logger.level > logging.INFO),
-        unit_scale=True,
-        desc="Copying file",
-    ) as pbar:
-        while True:
-            buf = fsrc.read(length)
-            if not buf:
-                break
-            fdst.write(buf)
-            copied = len(buf)
-            pbar.update(copied)
 
 
 class CubeBeams(NamedTuple):

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1025,6 +1025,7 @@ def smooth_fits_cube(
     tolerance: float = 0.0001,
     epsilon: float = 0.0005,
     nsamps: int = 200,
+    ncores: Optional[int] = None,
 ):
     """main script
 
@@ -1116,7 +1117,7 @@ def smooth_fits_cube(
     logger.info("Initialising output files")
 
     # Init output files and retrieve file names
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=ncores) as executor:
         futures = []
         for cube_data, common_beam_data in zip(cube_data_list, common_beam_data_list):
             future = executor.submit(
@@ -1132,7 +1133,7 @@ def smooth_fits_cube(
             futures.append(future)
     outfiles = [future.result() for future in futures]
 
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=ncores) as executor:
         futures = []
         for cube_data, common_beam_data, outfile in zip(
             cube_data_list, common_beam_data_list, outfiles
@@ -1175,7 +1176,7 @@ def cli():
 
     # Parse the command line options
     parser = argparse.ArgumentParser(
-        description=descStr, formatter_class=argparse.RawTextHelpFormatter
+        description=descStr, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument(
@@ -1344,6 +1345,13 @@ def cli():
         help="nsamps for radio_beam.commonbeam.",
     )
 
+    parser.add_argument(
+        "--ncores",
+        type=int,
+        default=None,
+        help="Number of cores to use for parallelisation. If None, use all available cores.",
+    )
+
     args = parser.parse_args()
 
     # Set up logging
@@ -1369,6 +1377,7 @@ def cli():
         ref_chan=args.ref_chan,
         tolerance=args.tolerance,
         epsilon=args.epsilon,
+        ncores=args.ncores,
     )
 
 

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1312,7 +1312,7 @@ def cli():
         epsilon=args.epsilon,
         ncores=args.ncores,
         nsamps=args.nsamps,
-        executor_type=args.executor_type
+        executor_type=args.executor_type,
     )
 
 

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import List, Literal, NamedTuple, Optional
+from typing import List, Literal, NamedTuple, Optional, Tuple
 
 import numpy as np
 from astropy import units as u
@@ -918,7 +918,7 @@ def smooth_fits_cube(
     epsilon: float = 0.0005,
     nsamps: int = 200,
     ncores: Optional[int] = None,
-) -> tuple[List[CubeData], List[CommonBeamData]]:
+) -> Tuple[List[CubeData], List[CommonBeamData]]:
     """Convolve a set of FITS cubes to a common beam.
 
     Args:
@@ -948,7 +948,7 @@ def smooth_fits_cube(
         ValueError: If number of channels are not equal.
 
     Returns:
-        tuple[List[CubeData], List[CommonBeamData]]: Cube data and common beam data.
+        Tuple[List[CubeData], List[CommonBeamData]]: Cube data and common beam data.
     """
     if dryrun:
         logger.info("Doing a dry run -- no files will be saved")

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1312,6 +1312,7 @@ def cli():
         epsilon=args.epsilon,
         ncores=args.ncores,
         nsamps=args.nsamps,
+        executor_type=args.executor_type
     )
 
 

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -2,6 +2,7 @@
 """ Convolve ASKAP cubes to common resolution """
 __author__ = "Alec Thomson"
 
+import gc
 import logging
 import sys
 import warnings
@@ -250,6 +251,8 @@ def smooth_plane(
         dy=dy,
         conv_mode=conv_mode,
     )
+    del plane
+    gc.collect()
     return newim
 
 
@@ -896,6 +899,9 @@ def smooth_and_write_plane(
 
         outfh[0].data[slicer] = newim.astype(np.float32)  # make sure data is 32-bit
         outfh.flush()
+        del newim
+        gc.collect()
+
     logger.info(f"{outfile}  - channel {chan} - Done")
 
 

--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -1130,7 +1130,7 @@ def cli():
         "--dryrun",
         dest="dryrun",
         action="store_true",
-        help="Compute common beam and stop [False].",
+        help="Compute common beam and stop.",
     )
 
     parser.add_argument(

--- a/racs_tools/convolve_uv.py
+++ b/racs_tools/convolve_uv.py
@@ -2,7 +2,7 @@
 """ Fast convolution in the UV domain """
 __author__ = "Wasim Raja"
 
-
+import gc
 from typing import Literal, NamedTuple, Optional, Tuple
 
 import astropy.units as units
@@ -492,6 +492,7 @@ def smooth(
         np.ndarray: Smoothed image.
 
     """
+    out_dtype = image.dtype
     conv_func = CONVOLUTION_FUNCTIONS.get(conv_mode, convolve)
     new_image, fac = conv_func(
         image=image,
@@ -501,6 +502,8 @@ def smooth(
         dy=dy,
         cutoff=cutoff,
     )
+    del image
+    gc.collect()
     logger.debug(f"Using scaling factor {fac}")
     if np.any(np.isnan(new_image)):
         logger.warning(f"{np.isnan(new_image).sum()} NaNs present in smoothed output")
@@ -508,4 +511,4 @@ def smooth(
     new_image *= fac
 
     # Ensure the output data-type is the same as the input
-    return new_image.astype(image.dtype)
+    return new_image.astype(out_dtype)

--- a/racs_tools/convolve_uv.py
+++ b/racs_tools/convolve_uv.py
@@ -367,7 +367,7 @@ CONVOLUTION_FUNCTIONS = {
 
 
 def parse_conv_mode(
-    conv_mode: Literal["robust", "scipy", "astropy", "astropy_fft"]
+    conv_mode: Literal["robust", "scipy", "astropy", "astropy_fft"],
 ) -> str:
     """Parse convolution mode
 

--- a/racs_tools/convolve_uv.py
+++ b/racs_tools/convolve_uv.py
@@ -3,17 +3,104 @@
 __author__ = "Wasim Raja"
 
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import astropy.units as units
 import numpy as np
 import scipy.signal
 from astropy import convolution
 from astropy import units as u
-from radio_beam import Beam
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+from radio_beam import Beam, Beams
+from radio_beam.utils import BeamError
 
 import racs_tools.gaussft as gaussft
+from racs_tools import au2
 from racs_tools.logging import logger
+
+
+def round_up(n: float, decimals: int = 0) -> float:
+    """Round to number of decimals
+
+    Args:
+        n (float): Number to round.
+        decimals (int, optional): Number of decimals. Defaults to 0.
+
+    Returns:
+        float: Rounded number.
+    """
+    multiplier = 10**decimals
+    return np.ceil(n * multiplier) / multiplier
+
+
+def my_ceil(a: float, precision: float = 0.0) -> float:
+    """Modified ceil function to round up to precision
+
+    Args:
+        a (float): Number to round.
+        precision (float, optional): Precision of rounding. Defaults to 0.
+
+    Returns:
+        float: Rounded number.
+    """
+    return np.round(a + 0.5 * 10 ** (-precision), precision)
+
+
+def get_nyquist_beam(
+    target_beam: Beam,
+    target_header: fits.Header,
+    beams: Beams,
+) -> Beam:
+    wcs = WCS(target_header)
+    pixelscales = proj_plane_pixel_scales(wcs)
+
+    dx = pixelscales[0] * u.deg
+    dy = pixelscales[1] * u.deg
+    if not np.isclose(dx, dy):
+        raise ValueError(f"GRID MUST BE SAME IN X AND Y. Got {dx=} and {dy=}")
+    grid = dy
+    # Get the minor axis of the convolving beams
+    minorcons = []
+    for beam in beams:
+        try:
+            minorcons += [target_beam.deconvolve(beam).minor.to(u.arcsec).value]
+        except BeamError as err:
+            logger.error(err)
+            logger.warning(
+                f"Could not deconvolve. New: {target_beam!r}, Old: {beam!r} - will set convolving beam to 0.0"
+            )
+            minorcons += [
+                target_beam.deconvolve(beam, failure_returns_pointlike=True)
+                .minor.to(u.arcsec)
+                .value
+            ]
+    minorcons = np.array(minorcons) * u.arcsec
+    samps = minorcons / grid.to(u.arcsec)
+    # Check that convolving beam will be Nyquist sampled
+    if any(samps.value < 2):
+        # Set the convolving beam to be Nyquist sampled
+        nyq_con_beam = Beam(major=grid * 2, minor=grid * 2, pa=0 * u.deg)
+        # Find new target based on common beam * Nyquist beam
+        # Not sure if this is best - but it works
+        nyq_beam = target_beam.convolve(nyq_con_beam)
+        nyq_beam = Beam(
+            major=my_ceil(nyq_beam.major.to(u.arcsec).value, precision=1) * u.arcsec,
+            minor=my_ceil(nyq_beam.minor.to(u.arcsec).value, precision=1) * u.arcsec,
+            pa=round_up(nyq_beam.pa.to(u.deg), decimals=2),
+        )
+        logger.info(f"Smallest common Nyquist sampled beam is: {nyq_beam!r}")
+        if target_beam is not None:
+            if target_beam < nyq_beam:
+                logger.warning("TARGET BEAM WILL BE UNDERSAMPLED!")
+                raise ValueError("CAN'T UNDERSAMPLE BEAM - EXITING")
+        else:
+            logger.warning("COMMON BEAM WILL BE UNDERSAMPLED!")
+            logger.warning("SETTING COMMON BEAM TO NYQUIST BEAM")
+            target_beam = nyq_beam
+
+    return target_beam
 
 
 def convolve(
@@ -91,22 +178,118 @@ def convolve(
     return im_conv, g_ratio
 
 
+CONVOLUTION_FUNCTIONS = {
+    "robust": convolve,
+    "scipy": convolution.convolve,
+    "astropy": convolution.convolve,
+    "astropy_fft": convolution.convolve_fft,
+}
+
+
+def parse_conv_mode(conv_mode: str) -> str:
+    logger.info(f"Convolution mode: {conv_mode}")
+    if conv_mode not in CONVOLUTION_FUNCTIONS.keys():
+        raise ValueError(
+            f"Please select valid convolution method! Expected one of {list(CONVOLUTION_FUNCTIONS.keys())}, got {conv_mode}"
+        )
+
+    logger.info(f"Using convolution method {conv_mode}")
+    if conv_mode == "robust":
+        logger.info("This is the most robust method. And fast!")
+    elif conv_mode == "scipy":
+        logger.info("This fast, but not robust to NaNs or small PSF changes")
+    else:
+        logger.info("This is slower, but robust to NaNs, but not to small PSF changes")
+
+    return conv_mode
+
+
+def get_convolving_beam(
+    old_beam: Beam,
+    new_beam: Beam,
+    dx: u.Quantity,
+    dy: u.Quantity,
+    cutoff: Optional[float] = None,
+) -> Tuple[Beam, float]:
+    """Get the beam to use for smoothing
+
+    Args:
+        old_beam (Beam): Current beam.
+        new_beam (Beam): Target beam.
+        dx (u.Quantity): Pixel size in x.
+        dy (u.Quantity): Pixel size in y.
+        cutoff (float, optional): Cutoff for beamsize in arcsec. Defaults to None.
+
+    Raises:
+        err: If beam deconvolution fails.
+
+    Returns:
+        Tuple[Beam, float]: Convolving beam and scaling factor.
+    """
+    logger.info(f"Current beam is {old_beam!r}")
+
+    if cutoff is not None and old_beam.major.to(u.arcsec) > cutoff * u.arcsec:
+        return (
+            Beam(
+                major=np.nan * u.deg,
+                minor=np.nan * u.deg,
+                pa=np.nan * u.deg,
+            ),
+            np.nan,
+        )
+
+    if new_beam == old_beam:
+        conbm = Beam(
+            major=0 * u.deg,
+            minor=0 * u.deg,
+            pa=0 * u.deg,
+        )
+        fac = 1.0
+        logger.warning(
+            f"New beam {new_beam!r} and old beam {old_beam!r} are the same. Won't attempt convolution."
+        )
+        return conbm, fac
+    try:
+        conbm = new_beam.deconvolve(old_beam)
+    except BeamError as err:
+        logger.error(err)
+        logger.warning(
+            f"Could not deconvolve. New: {new_beam!r}, Old: {old_beam!r} - will set convolving beam to 0.0"
+        )
+        conbm = new_beam.deconvolve(old_beam, failure_returns_pointlike=True)
+    fac, _, _, _, _ = au2.gauss_factor(
+        beamConv=[
+            conbm.major.to(u.arcsec).value,
+            conbm.minor.to(u.arcsec).value,
+            conbm.pa.to(u.deg).value,
+        ],
+        beamOrig=[
+            old_beam.major.to(u.arcsec).value,
+            old_beam.minor.to(u.arcsec).value,
+            old_beam.pa.to(u.deg).value,
+        ],
+        dx1=dx.to(u.arcsec).value,
+        dy1=dy.to(u.arcsec).value,
+    )
+
+    return conbm, fac
+
+
 def smooth(
     image: np.ndarray,
     old_beam: Beam,
-    final_beam: Beam,
+    new_beam: Beam,
     dx: u.Quantity,
     dy: u.Quantity,
-    sfactor: float,
-    conbeam: Beam = None,
     conv_mode: str = "robust",
+    cutoff: Optional[float] = None,
 ) -> np.ndarray:
     """Apply smoothing to image
 
     Args:
         image (np.ndarray): 2D image array.
         old_beam (Beam): Current beam.
-        final_beam (Beam): Target beam.
+        new_beam (Beam): Target beam.
         dx (u.Quantity): Pixel size in x.
         dy (u.Quantity): Pixel size in y.
         sfactor (float): Scaling factor.
@@ -115,14 +298,23 @@ def smooth(
 
     Returns:
         np.ndarray: Smoothed image.
+
     """
+
+    conbeam, sfactor = get_convolving_beam(
+        old_beam=old_beam,
+        new_beam=new_beam,
+        dx=dx,
+        dy=dy,
+        cutoff=cutoff,
+    )
+
     if np.isnan(sfactor):
         logger.warning("Beam larger than cutoff -- blanking")
-
         newim = np.ones_like(image) * np.nan
         return newim
     if conbeam is None:
-        conbeam = final_beam.deconvolve(old_beam)
+        conbeam = new_beam.deconvolve(old_beam)
     if np.isnan(conbeam):
         return image * np.nan
     if np.isnan(image).all():
@@ -132,7 +324,7 @@ def smooth(
     # using Beams package
     logger.debug(f"Old beam is {old_beam!r}")
     logger.debug(f"Using convolving beam {conbeam!r}")
-    logger.debug(f"Target beam is {final_beam!r}")
+    logger.debug(f"Target beam is {new_beam!r}")
     logger.debug(f"Using scaling factor {sfactor}")
     pix_scale = dy
 
@@ -143,7 +335,7 @@ def smooth(
         newim, fac = convolve(
             image.astype("f8"),
             old_beam,
-            final_beam,
+            new_beam,
             dx,
             dy,
         )

--- a/racs_tools/convolve_uv.py
+++ b/racs_tools/convolve_uv.py
@@ -3,7 +3,7 @@
 __author__ = "Wasim Raja"
 
 
-from typing import NamedTuple, Optional, Tuple
+from typing import Literal, NamedTuple, Optional, Tuple
 
 import astropy.units as units
 import numpy as np
@@ -146,6 +146,7 @@ def convolve(
         new_beam (Beam): Target image PSF.
         dx (u.Quantity): Grid size in x (e.g. CDELT1)
         dy (u.Quantity): Grid size in y (e.g. CDELT2)
+        cutoff (Optional[float], optional): Dummy cutoff for beamszie in arcsec. Defaults to None. NOT USED.
 
     Returns:
         ConvolutionResult: convolved image, scaling factor
@@ -214,6 +215,19 @@ def convolve_scipy(
     dy: u.Quantity,
     cutoff: Optional[float] = None,
 ) -> ConvolutionResult:
+    """Convolve using scipy's convolution
+
+    Args:
+        image (np.ndarray): Image to be convolved.
+        old_beam (Beam): Current beam.
+        new_beam (Beam): Target beam.
+        dx (u.Quantity): Pixel size in x.
+        dy (u.Quantity): Pixel size in y.
+        cutoff (Optional[float], optional): Cutoff for beamszie in arcsec. Defaults to None.
+
+    Returns:
+        ConvolutionResult: Convolved image, scaling factor.
+    """
     conbeam, sfactor = get_convolving_beam(
         old_beam=old_beam,
         new_beam=new_beam,
@@ -249,6 +263,19 @@ def convolve_astropy(
     dy: u.Quantity,
     cutoff: Optional[float] = None,
 ) -> ConvolutionResult:
+    """Convolve using astropy's convolution
+
+    Args:
+        image (np.ndarray): Image to be convolved.
+        old_beam (Beam): Current beam.
+        new_beam (Beam): Target beam.
+        dx (u.Quantity): Pixel size in x.
+        dy (u.Quantity): Pixel size in y.
+        cutoff (Optional[float], optional): Cutoff for beamszie in arcsec. Defaults to None.
+
+    Returns:
+        ConvolutionResult: Convolved image, scaling factor.
+    """
     conbeam, sfactor = get_convolving_beam(
         old_beam=old_beam,
         new_beam=new_beam,
@@ -287,6 +314,19 @@ def convolve_astropy_fft(
     dy: u.Quantity,
     cutoff: Optional[float] = None,
 ) -> ConvolutionResult:
+    """Convolve using astropy's FFT convolution
+
+    Args:
+        image (np.ndarray): Image to be convolved.
+        old_beam (Beam): Current beam.
+        new_beam (Beam): Target beam.
+        dx (u.Quantity): Pixel size in x.
+        dy (u.Quantity): Pixel size in y.
+        cutoff (Optional[float], optional): Cutoff for beamszie in arcsec. Defaults to None.
+
+    Returns:
+        ConvolutionResult: Convolved image, scaling factor.
+    """
     conbeam, sfactor = get_convolving_beam(
         old_beam=old_beam,
         new_beam=new_beam,
@@ -326,7 +366,17 @@ CONVOLUTION_FUNCTIONS = {
 }
 
 
-def parse_conv_mode(conv_mode: str) -> str:
+def parse_conv_mode(
+    conv_mode: Literal["robust", "scipy", "astropy", "astropy_fft"]
+) -> str:
+    """Parse convolution mode
+
+    Args:
+        conv_mode (str): Convolution mode.
+
+    Returns:
+        str: Convolution mode.
+    """
     logger.info(f"Convolution mode: {conv_mode}")
     if conv_mode not in CONVOLUTION_FUNCTIONS.keys():
         raise ValueError(
@@ -424,10 +474,10 @@ def smooth(
     new_beam: Beam,
     dx: u.Quantity,
     dy: u.Quantity,
-    conv_mode: str = "robust",
+    conv_mode: Literal["robust", "scipy", "astropy", "astropy_fft"] = "robust",
     cutoff: Optional[float] = None,
 ) -> np.ndarray:
-    """Apply smoothing to image
+    """Apply smoothing to image in Jy/beam
 
     Args:
         image (np.ndarray): 2D image array.

--- a/racs_tools/gaussft.py
+++ b/racs_tools/gaussft.py
@@ -50,11 +50,13 @@ def gaussft(
     )
     bmaj_rad, bmin_rad, bpa_rad = bmaj * deg2rad, bmin * deg2rad, bpa * deg2rad
 
-    sx, sy = bmaj_rad / (2 * np.sqrt(2.0 * np.log(2.0))), bmin_rad / (
-        2 * np.sqrt(2.0 * np.log(2.0))
+    sx, sy = (
+        bmaj_rad / (2 * np.sqrt(2.0 * np.log(2.0))),
+        bmin_rad / (2 * np.sqrt(2.0 * np.log(2.0))),
     )
-    sx_in, sy_in = bmaj_in_rad / (2.0 * np.sqrt(2.0 * np.log(2.0))), bmin_in_rad / (
-        2.0 * np.sqrt(2.0 * np.log(2.0))
+    sx_in, sy_in = (
+        bmaj_in_rad / (2.0 * np.sqrt(2.0 * np.log(2.0))),
+        bmin_in_rad / (2.0 * np.sqrt(2.0 * np.log(2.0))),
     )
 
     u_cosbpa, u_sinbpa = u * np.cos(bpa_rad), u * np.sin(bpa_rad)

--- a/racs_tools/getnoise_list.py
+++ b/racs_tools/getnoise_list.py
@@ -2,9 +2,8 @@
 """ Find bad channels by checking statistics of each channel image. """
 
 import argparse
-import logging
 import warnings
-from typing import List, Tuple, Union
+from typing import Tuple, Union
 
 import astropy.units as u
 import numpy as np

--- a/racs_tools/getnoise_list.py
+++ b/racs_tools/getnoise_list.py
@@ -11,7 +11,7 @@ from astropy.stats import mad_std
 from spectral_cube import SpectralCube
 from spectral_cube.utils import SpectralCubeWarning
 
-from racs_tools.logging import logger, setup_logger
+from racs_tools.logging import logger, set_verbosity
 
 warnings.filterwarnings(action="ignore", category=SpectralCubeWarning, append=True)
 
@@ -30,7 +30,7 @@ def getcube(filename: str) -> SpectralCube:
         SpectralCube: Data cube
     """
     cube = SpectralCube.read(filename)
-    mask = ~(cube == 0 * u.jansky / u.beam)
+    mask = ~(cube == 0 * cube.unit)
     cube = cube.with_mask(mask)
     return cube
 
@@ -189,7 +189,7 @@ def main(
 
     if outfile:
         logger.info(f"Saving bad files to {outfile}")
-        np.savetxt(outfile, totalbad)
+        np.savetxt(outfile, totalbad.astype(int), fmt="%d")
 
 
 def cli() -> None:
@@ -256,9 +256,9 @@ def cli() -> None:
     args = parser.parse_args()
 
     # Set up logging
-    logger = setup_logger(
+    set_verbosity(
+        logger=logger,
         verbosity=args.verbosity,
-        filename=args.logfile,
     )
 
     main(

--- a/racs_tools/logging.py
+++ b/racs_tools/logging.py
@@ -4,19 +4,12 @@
 import logging
 from typing import Optional
 
-try:
-    from mpi4py import MPI
-
-    myPE = MPI.COMM_WORLD.Get_rank()
-except ImportError:
-    myPE = 0
-
 logging.captureWarnings(True)
 logger = logging.getLogger("racs_tools")
 logger.setLevel(logging.WARNING)
 
 formatter = logging.Formatter(
-    fmt=f"[{myPE}] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
+    fmt=f"[%(threadName)s] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 

--- a/racs_tools/logging.py
+++ b/racs_tools/logging.py
@@ -2,22 +2,56 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Optional
+import multiprocessing as mp
+from logging.handlers import QueueHandler, QueueListener
+from typing import Optional, Tuple
 
 logging.captureWarnings(True)
-logger = logging.getLogger("racs_tools")
-logger.setLevel(logging.WARNING)
 
-formatter = logging.Formatter(
-    fmt="[%(threadName)s] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
+# Following guide from gwerbin/multiprocessing_logging.py
+# https://gist.github.com/gwerbin/e9ab7a88fef03771ab0bf3a11cf921bc
 
 
 def setup_logger(
-    verbosity: int = 0,
     filename: Optional[str] = None,
-):
+) -> Tuple[logging.Logger, QueueListener, mp.Queue]:
+    """Setup a logger
+
+    Args:
+        filename (Optional[str], optional): Output log file. Defaults to None.
+
+    Returns:
+        Tuple[logging.Logger, QueueListener, mp.Queue]: Logger, log listener and log queue
+    """
+    logger = logging.getLogger("racs_tools")
+    logger.setLevel(logging.WARNING)
+    formatter = logging.Formatter(
+        fmt="[%(threadName)s] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    if filename is not None:
+        fh = logging.FileHandler(filename)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    log_queue = mp.Queue()
+    log_listener = QueueListener(log_queue, ch)
+
+    return logger, log_listener, log_queue
+
+
+def set_verbosity(logger: logging.Logger, verbosity: int) -> None:
+    """Set the logger verbosity
+
+    Args:
+        logger (logging.Logger): The logger
+        verbosity (int): Verbosity level
+    """
     if verbosity == 0:
         level = logging.WARNING
     elif verbosity == 1:
@@ -25,17 +59,22 @@ def setup_logger(
     elif verbosity >= 2:
         level = logging.DEBUG
 
-    ch = logging.StreamHandler()
-    ch.setLevel(level)
-    ch.setFormatter(formatter)
-
     logger.setLevel(level)
-    logger.addHandler(ch)
 
-    if filename is not None:
-        fh = logging.FileHandler(filename)
-        fh.setLevel(level)
-        fh.setFormatter(formatter)
-        logger.addHandler(fh)
 
-    return logger
+def init_worker(log_queue: mp.Queue, verbosity: int = 0) -> None:
+    """Initialise a worker process with a logger
+
+    Args:
+        log_queue (mp.Queue): The log queue
+        verbosity (int, optional): Verbosity level. Defaults to 0.
+    """
+    logger = logging.getLogger("racs_tools")
+
+    set_verbosity(logger, verbosity)
+
+    handler = QueueHandler(log_queue)
+    logger.addHandler(handler)
+
+
+logger, log_listener, log_queue = setup_logger()

--- a/racs_tools/logging.py
+++ b/racs_tools/logging.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("racs_tools")
 logger.setLevel(logging.WARNING)
 
 formatter = logging.Formatter(
-    fmt=f"[%(threadName)s] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
+    fmt="[%(threadName)s] %(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 

--- a/racs_tools/parallel.py
+++ b/racs_tools/parallel.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+""" Utilities for parallelism """
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from typing import Dict, Literal, TypeVar
+
+from racs_tools.logging import logger
+
+try:
+    from mpi4py.futures import MPIPoolExecutor
+except ImportError:
+    logger.warning("MPI not available")
+    MPIPoolExecutor = None
+
+Executor = TypeVar("Executor", ThreadPoolExecutor, ProcessPoolExecutor, MPIPoolExecutor)
+
+EXECUTORS: Dict[Literal["thread", "process", "mpi"], Executor] = {
+    "thread": ThreadPoolExecutor,
+    "process": ProcessPoolExecutor,
+    "mpi": MPIPoolExecutor,
+}
+
+
+def get_executor(
+    executor_type: Literal["thread", "process", "mpi"] = "thread",
+) -> Executor:
+    """Get an executor based on the type
+
+    Args:
+        executor_type (Literal["thread", "process", "mpi"], optional): Type of executor. Defaults to "thread".
+
+    Raises:
+        ValueError: If the executor type is not available
+
+    Returns:
+        Executor: Executor class
+    """
+    ExecutorClass: Executor = EXECUTORS.get(executor_type, ThreadPoolExecutor)
+    if ExecutorClass is None:
+        raise ValueError(f"Executor type {executor_type} is not available!")
+    logger.info(f"Using {ExecutorClass.__name__} for parallelisation")
+    return ExecutorClass

--- a/racs_tools/parallel.py
+++ b/racs_tools/parallel.py
@@ -5,10 +5,12 @@ from typing import Dict, Literal, TypeVar
 
 from racs_tools.logging import logger
 
+# logger = setup_logger()
+
 try:
     from mpi4py.futures import MPIPoolExecutor
 except ImportError:
-    logger.warning("MPI not available")
+    logger.debug("MPI not available")
     MPIPoolExecutor = None
 
 Executor = TypeVar("Executor", ThreadPoolExecutor, ProcessPoolExecutor, MPIPoolExecutor)

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -4,14 +4,12 @@
 import logging
 import shutil
 import subprocess as sp
-from os import path
 from pathlib import Path
-from typing import List, NamedTuple, Tuple, Union
+from typing import NamedTuple
 
 import astropy.units as u
 import numpy as np
 import pytest
-import schwimmbad
 from astropy.io import fits
 from radio_beam import Beam
 
@@ -141,16 +139,14 @@ def check_images(image_1: Path, image_2: Path) -> bool:
 
 def test_robust(make_2d_image: TestImage, mirsmooth: TestImage):
     """Test the robust convolution."""
-    with schwimmbad.SerialPool() as pool:
-        beamcon_2D.main(
-            pool=pool,
-            infile=[make_2d_image.path.as_posix()],
-            suffix="robust",
-            conv_mode="robust",
-            bmaj=mirsmooth.beam.major.to(u.arcsec).value,
-            bmin=mirsmooth.beam.minor.to(u.arcsec).value,
-            bpa=mirsmooth.beam.pa.to(u.deg).value,
-        )
+    beamcon_2D.smooth_fits_files(
+        infile_list=[make_2d_image.path],
+        suffix="robust",
+        conv_mode="robust",
+        bmaj=mirsmooth.beam.major.to(u.arcsec).value,
+        bmin=mirsmooth.beam.minor.to(u.arcsec).value,
+        bpa=mirsmooth.beam.pa.to(u.deg).value,
+    )
 
     fname_beamcon = make_2d_image.path.with_suffix(".robust.fits")
     assert check_images(mirsmooth.path, fname_beamcon), "Beamcon does not match miriad"
@@ -158,16 +154,14 @@ def test_robust(make_2d_image: TestImage, mirsmooth: TestImage):
 
 def test_astropy(make_2d_image: TestImage, mirsmooth: TestImage):
     """Test the astropy convolution."""
-    with schwimmbad.SerialPool() as pool:
-        beamcon_2D.main(
-            pool=pool,
-            infile=[make_2d_image.path.as_posix()],
-            suffix="astropy",
-            conv_mode="astropy",
-            bmaj=mirsmooth.beam.major.to(u.arcsec).value,
-            bmin=mirsmooth.beam.minor.to(u.arcsec).value,
-            bpa=mirsmooth.beam.pa.to(u.deg).value,
-        )
+    beamcon_2D.smooth_fits_files(
+        infile_list=[make_2d_image.path],
+        suffix="astropy",
+        conv_mode="astropy",
+        bmaj=mirsmooth.beam.major.to(u.arcsec).value,
+        bmin=mirsmooth.beam.minor.to(u.arcsec).value,
+        bpa=mirsmooth.beam.pa.to(u.deg).value,
+    )
 
     fname_beamcon = make_2d_image.path.with_suffix(".astropy.fits")
     assert check_images(mirsmooth.path, fname_beamcon), "Beamcon does not match miriad"
@@ -175,16 +169,14 @@ def test_astropy(make_2d_image: TestImage, mirsmooth: TestImage):
 
 def test_scipy(make_2d_image: TestImage, mirsmooth: TestImage):
     """Test the scipy convolution."""
-    with schwimmbad.SerialPool() as pool:
-        beamcon_2D.main(
-            pool=pool,
-            infile=[make_2d_image.path.as_posix()],
-            suffix="scipy",
-            conv_mode="scipy",
-            bmaj=mirsmooth.beam.major.to(u.arcsec).value,
-            bmin=mirsmooth.beam.minor.to(u.arcsec).value,
-            bpa=mirsmooth.beam.pa.to(u.deg).value,
-        )
+    beamcon_2D.smooth_fits_files(
+        infile_list=[make_2d_image.path],
+        suffix="scipy",
+        conv_mode="scipy",
+        bmaj=mirsmooth.beam.major.to(u.arcsec).value,
+        bmin=mirsmooth.beam.minor.to(u.arcsec).value,
+        bpa=mirsmooth.beam.pa.to(u.deg).value,
+    )
 
     fname_beamcon = make_2d_image.path.with_suffix(".scipy.fits")
     assert check_images(mirsmooth.path, fname_beamcon), "Beamcon does not match miriad"
@@ -219,10 +211,9 @@ def test_smooth(make_2d_image: TestImage, mirsmooth: TestImage):
         smooth_data = smooth(
             image=make_2d_image.data,
             old_beam=old_beam,
-            final_beam=target_beam,
+            new_beam=target_beam,
             dx=make_2d_image.pix_scale,
             dy=make_2d_image.pix_scale,
-            sfactor=fac,
             conv_mode=conv_mode,
         )
         assert np.allclose(

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -154,8 +154,8 @@ def mirsmooth_3d(make_3d_image: TestImage) -> TestImage:
 
 def test_robust_3d(make_3d_image, mirsmooth_3d):
     """Test the robust mode."""
-    beamcon_3D.main(
-        infile=[make_3d_image.path.as_posix()],
+    beamcon_3D.smooth_fits_cube(
+        infiles_list=[make_3d_image.path],
         suffix="robust",
         conv_mode="robust",
         mode="total",

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -24,9 +24,21 @@ from .test_2d import TestImage, check_images
 def make_3d_image(
     tmpdir: str,
     beams: Beams = Beams(
-        major=[50, 50, 50] * u.arcsec,
-        minor=[10, 10, 10] * u.arcsec,
-        pa=[0, 0, 0] * u.deg,
+        major=[
+            50,
+        ]
+        * 100
+        * u.arcsec,
+        minor=[
+            10,
+        ]
+        * 100
+        * u.arcsec,
+        pa=[
+            0,
+        ]
+        * 100
+        * u.deg,
     ),
 ) -> TestImage:
     """Make a fake 3D image from with a Gaussian beam.
@@ -42,9 +54,11 @@ def make_3d_image(
     freqs = np.linspace(1, 2, len(beams)) * u.GHz
 
     cube = []
-    for beam in beams:
+    peaks = np.random.uniform(0.1, 10, len(beams))
+    for beam, peak in zip(beams, peaks):
         data = beam.as_kernel(pixscale=pix_scale, x_size=100, y_size=100).array
         data /= data.max()
+        data *= peak
         cube.append(data)
 
     cube = np.array(cube)[np.newaxis]

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
 import shutil
 import subprocess as sp
-import unittest
 from pathlib import Path
 
 import astropy.units as u
 import numpy as np
 import pytest
-import schwimmbad
 from astropy.io import fits
 from astropy.table import Table
 from radio_beam import Beam, Beams

--- a/tests/test_3d.py
+++ b/tests/test_3d.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 import shutil
 import subprocess as sp
+import unittest
 from pathlib import Path
 
 import astropy.units as u
 import numpy as np
 import pytest
+import schwimmbad
 from astropy.io import fits
 from astropy.table import Table
 from radio_beam import Beam, Beams


### PR DESCRIPTION
A relatively big refactor of the beamcon scripts. Mostly for internal sanity and doing away with dictionaries in favour of namedtuples.

A big change for the attention of @wasimraja81, @axshen and others is that I also remove MPI functionality here. In place, I use threading (through the built-in `concurrent.futures` API). This has a nice speed bonus, as well as reducing the code footprint. Since we use Numpy+Numba, or we wait on I/O, the Python GIL is mostly not an issue. 

The CLI calls remain identical, with the exception of MPI options being removed. If you have big issues with this change, I'm happy to hear feedback.

This will target a major version bump.

Still got some documentation to finish up.