### PR TITLE
Catch a (0,) dimensionality issue on spectral axis in beamcon_3D

### DIFF
--- a/racs_tools/beamcon_3D.py
+++ b/racs_tools/beamcon_3D.py
@@ -331,6 +331,9 @@ def _get_commonbeams(
         f"Expected target_beam to be type Beam or None, got {type(target_beam)}"
     )
 
+    logger.info("Finding common beam for all channels and cubes")
+    logger.info(f"Number of channels {nchans=}")
+
     if mode == "natural":
         big_beams = []
         for n in trange(
@@ -546,6 +549,7 @@ def _get_commonbeams(
             pa=commonbeams.pa * 0,
         )
 
+    logger.info(f"Number of common beams: {len(commonbeams)}")
     return commonbeams
 
 
@@ -765,10 +769,15 @@ def initfiles(
 
     ## Header
     spec_axis = wcs.spectral
-    crpix = int(spec_axis.wcs.crpix)
+    # account for either an float or array of single float. Anything else should fail!
+    crpix = (
+        int(np.squeeze(spec_axis.wcs.crpix))
+        if isinstance(spec_axis.wcs.crpix, np.ndarray)
+        else int(spec_axis.wcs.crpix)
+    )
     nchans = spec_axis.array_shape[0]
     assert nchans == len(commonbeams), (
-        "Number of channels in header and commonbeams do not match"
+        f"Number of channels {nchans=} in header and commonbeams {len(commonbeams)=} do not match"
     )
     chans = np.arange(nchans)
     if ref_chan is None:


### PR DESCRIPTION
I recently installed a new environment for some racs-all testing and started to run into a strange issue. 

```
File "/datasets/work/jones-storage/work/miniconda/miniforge3/envs/flint_racsall/lib/python3.12/site-packages/racs_tools/beamcon_3D.py", line 768, in initfiles
    crpix = int(spec_axis.wcs.crpix)
            ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

Digging into this is appears as though a numpy array of length 1 is being returned in the `spec_axis.wcs.crpix` WCS instance. The attempt to `int` therefore fails, even though the array was of length 1. I am not sure if this was a change in  numpy or astropy, as it honestly could be either. I am relatively certain it is not a `fitscube` issue as the cube there has gone through the `astropy.io.fits` infrastructure, and read in as such correctly as well. 

This PR has a type check, and if a numpy array is found it is first squeezed before passing through the int typecast. I believe it is a backwards compatible change, i.e. whatever changed in whatever dependency will contrinue to work.  